### PR TITLE
Update checking of grandparent items

### DIFF
--- a/lib/middleman-pagegroups/extension.rb
+++ b/lib/middleman-pagegroups/extension.rb
@@ -420,7 +420,7 @@ class MiddlemanPageGroups < ::Middleman::Extension
           # Handle preceding path parts, first, if there's a grandparent (all
           # top level items have a parent and aren't part of this case). These
           # will have already been set because we've done shallower paths first.
-          if resource.parent.parent
+          if resource.parent && resource.parent.parent
             parent_path_parts = File.dirname(resource.parent.destination_path).split('/')
             path_parts = parent_path_parts + path_parts[parent_path_parts.count..-1]
           end


### PR DESCRIPTION
When using Middleman's Localization features the grandparent check fails when an object is null. This change fixes that issue and allows PageGroups and Localization to work together.

Previous error that was being raised:
/Users/markor/git/middleman-pagegroups-1.0.6/lib/middleman-pagegroups/extension.rb:423:in `block in manipulate_resource_list': undefined method `parent' for nil:NilClass (NoMethodError)

With this change that error no longer appears and the pages build as expected.